### PR TITLE
Running the Azurite emulator

### DIFF
--- a/GameStore/docker-compose for Development Environment/docker-compose.yml
+++ b/GameStore/docker-compose for Development Environment/docker-compose.yml
@@ -28,6 +28,15 @@ services:
         - keycloak-GameStore-data:/opt/keycloak/data
     command: ["start-dev"]
 
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:latest #3.34.0
+    container_name: azurite_GameStore
+    ports:
+        - "10000:10000"
+    volumes:
+        - azurite-GameStore-data:/data
+
 volumes:
   smtp4dev-GameStore-data:
   keycloak-GameStore-data:  
+  azurite-GameStore-data:


### PR DESCRIPTION
Running the Azurite emulator

Add Azurite service to docker-compose.yml

This change introduces an Azure Storage emulator to the project.

- Added Azurite service with the latest image.
- Configured Azurite to expose port 10000.
- Created a new volume for Azurite data.